### PR TITLE
point virgule dans island controller

### DIFF
--- a/app/controllers/islands_controller.rb
+++ b/app/controllers/islands_controller.rb
@@ -15,6 +15,6 @@ class IslandsController < ApplicationController
   private
 
   def list_params
-    params.require(:list).permit(:name, :description, :location, :gps_longitude, :gps_latitude, :price_per_night; :capacity)
+    params.require(:list).permit(:name, :description, :location, :gps_longitude, :gps_latitude, :price_per_night, :capacity)
       end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.1].define(version: 2024_11_19_133952) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
j'ai corrigé cette ligne :  (point virgule à la place de virgule)

    params.require(:list).permit(:name, :description, :location, :gps_longitude, :gps_latitude, :price_per_night, :capacity)
